### PR TITLE
feat: 根据新结构体定义更新 lddata_json.hpp 序列化

### DIFF
--- a/include/lddata_json.hpp
+++ b/include/lddata_json.hpp
@@ -1,0 +1,335 @@
+#pragma once
+
+#include "vision_type/vision_type.hpp"
+#include "multiperception/common/nlohmann/json.hpp"
+
+#include <fstream>
+#include <string>
+
+namespace vexus {
+namespace vision {
+
+using json = nlohmann::json;
+
+// ─────────────────────────────────────────────
+//  基础类型
+// ─────────────────────────────────────────────
+
+inline void to_json(json &j, const Point3d &p) {
+    j = json{{"x", p.x}, {"y", p.y}, {"z", p.z}};
+}
+
+inline void to_json(json &j, const Quaternion &q) {
+    j = json{{"qw", q.qw}, {"qx", q.qx}, {"qy", q.qy}, {"qz", q.qz}};
+}
+
+// ─────────────────────────────────────────────
+//  RoadStructureBaseData
+// ─────────────────────────────────────────────
+
+inline void to_json(json &j, const RoadStructureBaseData &d) {
+    j = json{
+        {"id",               d.id},
+        {"detection_status", d.detection_status},
+        {"confidence",       d.confidence}
+    };
+}
+
+// ─────────────────────────────────────────────
+//  Route Map Data
+// ─────────────────────────────────────────────
+
+inline void to_json(json &j, const JunctionData &d) {
+    j = json{
+        {"id",                    d.id},
+        {"junction_type",         d.junction_type},
+        {"boundary",              d.boundary},
+        {"from_section_ids",      d.from_section_ids},
+        {"to_section_ids",        d.to_section_ids},
+        {"force_using_map_version", d.force_using_map_version},
+        {"map_source",            d.map_source},
+        {"boundary_lla",          d.boundary_lla},
+        {"boundary_ego",          d.boundary_ego}
+    };
+}
+
+inline void to_json(json &j, const LaneData &d) {
+    j = json{
+        {"id",                   d.id},
+        {"lane_type",            d.lane_type},
+        {"turn_type",            d.turn_type},
+        {"trans_type",           d.trans_type},
+        {"lane_direction",       d.lane_direction},
+        {"left_line_id",         d.left_line_id},
+        {"right_line_id",        d.right_line_id},
+        {"center_points",        d.center_points},
+        {"section_id",           d.section_id},
+        {"intersection_id",      d.intersection_id},
+        {"left_lane_id",         d.left_lane_id},
+        {"right_lane_id",        d.right_lane_id},
+        {"length",               d.length},
+        {"lane_widths",          d.lane_widths},
+        {"headings",             d.headings},
+        {"longitudinal_slopes",  d.longitudinal_slopes},
+        {"lateral_slopes",       d.lateral_slopes},
+        {"curvature_radius",     d.curvature_radius},
+        {"max_speed",            d.max_speed},
+        {"min_speed",            d.min_speed},
+        {"successor_link_ids",   d.successor_link_ids},
+        {"predecessor_link_ids", d.predecessor_link_ids},
+        {"stop_line_ids",        d.stop_line_ids},
+        {"cross_walk_ids",       d.cross_walk_ids},
+        {"speed_bump_ids",       d.speed_bump_ids},
+        {"area_ids",             d.area_ids},
+        {"detection_status",     d.detection_status},
+        {"visual_diff",          d.visual_diff},
+        {"is_opposite",          d.is_opposite},
+        {"experience_spdlmt",    d.experience_spdlmt},
+        {"force_avoidance_line", d.force_avoidance_line},
+        {"center_points_lla",    d.center_points_lla},
+        {"center_points_ego",    d.center_points_ego}
+    };
+}
+
+inline void to_json(json &j, const SectionData &d) {
+    j = json{
+        {"id",                   d.id},
+        {"section_class",        d.section_class},
+        {"section_type",         d.section_type},
+        {"section_direction",    d.section_direction},
+        {"positive_slope",       d.positive_slope},
+        {"toll_type",            d.toll_type},
+        {"is_routing_section",   d.is_routing_section},
+        {"center_points",        d.center_points},
+        {"intersection_id",      d.intersection_id},
+        {"length",               d.length},
+        {"lane_ids",             d.lane_ids},
+        {"left_boundary_ids",    d.left_boundary_ids},
+        {"right_boundary_ids",   d.right_boundary_ids},
+        {"successor_link_ids",   d.successor_link_ids},
+        {"predecessor_link_ids", d.predecessor_link_ids},
+        {"traffic_light_ids",    d.traffic_light_ids},
+        {"traffic_sign_ids",     d.traffic_sign_ids},
+        {"from_junction_ids",    d.from_junction_ids},
+        {"to_junction_ids",      d.to_junction_ids},
+        {"opposite_section_ids", d.opposite_section_ids},
+        {"is_strategic_section", d.is_strategic_section},
+        {"is_sparsify",          d.is_sparsify},
+        {"experience_spd",       d.experience_spd},
+        {"force_using_map",      d.force_using_map},
+        {"center_points_lla",    d.center_points_lla},
+        {"center_points_ego",    d.center_points_ego}
+    };
+}
+
+inline void to_json(json &j, const LaneLinkData &d) {
+    j = json{
+        {"id",             d.id},
+        {"from_lane_id",   d.from_lane_id},
+        {"to_lane_id",     d.to_lane_id},
+        {"link_type",      d.link_type},
+        {"ref_points",     d.ref_points},
+        {"section_link_id", d.section_link_id}
+    };
+}
+
+// ─────────────────────────────────────────────
+//  Semantic Map Data
+// ─────────────────────────────────────────────
+
+inline void to_json(json &j, const AreaData &d) {
+    j = json{
+        {"id",               d.id},
+        {"detection_status", d.detection_status},
+        {"confidence",       d.confidence},
+        {"area_type",        d.area_type},
+        {"boundary",         d.boundary},
+        {"lane_ids",         d.lane_ids},
+        {"boundary_lla",     d.boundary_lla},
+        {"boundary_ego",     d.boundary_ego}
+    };
+}
+
+inline void to_json(json &j, const CrosswalkData &d) {
+    j = json{
+        {"id",               d.id},
+        {"detection_status", d.detection_status},
+        {"confidence",       d.confidence},
+        {"boundary",         d.boundary},
+        {"lane_ids",         d.lane_ids},
+        {"boundary_lla",     d.boundary_lla},
+        {"boundary_ego",     d.boundary_ego}
+    };
+}
+
+inline void to_json(json &j, const StopLineData &d) {
+    j = json{
+        {"id",               d.id},
+        {"points",           d.points},
+        {"lane_ids",         d.lane_ids},
+        {"detection_status", d.detection_status},
+        {"confidence",       d.confidence},
+        {"points_lla",       d.points_lla},
+        {"points_ego",       d.points_ego}
+    };
+}
+
+inline void to_json(json &j, const LineSegmentData &d) {
+    j = json{
+        {"id",               d.id},
+        {"line_type",        d.line_type},
+        {"line_style",       d.line_style},
+        {"color",            d.color},
+        {"width",            d.width},
+        {"detection_status", d.detection_status},
+        {"confidence",       d.confidence},
+        {"points",           d.points},
+        {"points_lla",       d.points_lla},
+        {"points_ego",       d.points_ego}
+    };
+}
+
+inline void to_json(json &j, const LineData &d) {
+    j = json{
+        {"id",            d.id},
+        {"left_lane_id",  d.left_lane_id},
+        {"right_lane_id", d.right_lane_id},
+        {"line_segments", d.line_segments},
+        {"obs_age",       d.obs_age},
+        {"is_opposite",   d.is_opposite}
+    };
+}
+
+inline void to_json(json &j, const ObjectData &d) {
+    j = json{
+        {"id",               d.id},
+        {"centroid",         d.centroid},
+        {"detection_status", d.detection_status},
+        {"confidence",       d.confidence},
+        {"quaternion",       d.quaternion},
+        {"length",           d.length},
+        {"width",            d.width},
+        {"height",           d.height},
+        {"lane_ids",         d.lane_ids},
+        {"confidence_level", d.confidence_level},
+        {"junction_id",      d.junction_id},
+        {"centroid_lla",     d.centroid_lla},
+        {"centroid_ego",     d.centroid_ego}
+    };
+}
+
+inline void to_json(json &j, const TrafficLightData &d) {
+    json obj_j;
+    to_json(obj_j, d.object_data);
+    j = obj_j;
+    j["distance"]    = d.distance;
+    j["countdown"]   = d.countdown;
+    j["status"]      = d.status;
+    j["countdown_d"] = d.countdown_d;
+}
+
+inline void to_json(json &j, const TrafficSignData &d) {
+    json obj_j;
+    to_json(obj_j, d.object_data);
+    j = obj_j;
+    j["type"] = d.type;
+}
+
+inline void to_json(json &j, const TrafficConeData &d) {
+    json obj_j;
+    to_json(obj_j, d.object_data);
+    j = obj_j;
+    j["type"]          = d.type;
+    j["obs_age"]       = d.obs_age;
+    j["attribute_age"] = d.attribute_age;
+    j["loc_estimation"] = d.loc_estimation;
+}
+
+inline void to_json(json &j, const RoadMarkerData &d) {
+    json obj_j;
+    to_json(obj_j, d.object_data);
+    j = obj_j;
+    j["type"]             = d.type;
+    j["orientation_type"] = d.orientation_type;
+    j["color"]            = d.color;
+    j["semantic"]         = d.semantic;
+    j["obs_age"]          = d.obs_age;
+    j["attribute_age"]    = d.attribute_age;
+}
+
+inline void to_json(json &j, const PoleData &d) {
+    j = json{
+        {"id",               d.id},
+        {"detection_status", d.detection_status},
+        {"confidence",       d.confidence},
+        {"lane_ids",         d.lane_ids},
+        {"bottom_point",     d.bottom_point},
+        {"top_point",        d.top_point},
+        {"type",             d.type}
+    };
+}
+
+inline void to_json(json &j, const SpeedBumpData &d) {
+    j = json{
+        {"id",               d.id},
+        {"detection_status", d.detection_status},
+        {"confidence",       d.confidence},
+        {"type",             d.type},
+        {"points",           d.points},
+        {"lane_ids",         d.lane_ids},
+        {"points_lla",       d.points_lla},
+        {"points_ego",       d.points_ego}
+    };
+}
+
+// ─────────────────────────────────────────────
+//  顶层：LDData
+// ─────────────────────────────────────────────
+
+inline void to_json(json &j, const LDData &d) {
+    j = json{
+        {"areas",          d.areas},
+        {"cross_walks",    d.cross_walks},
+        {"sections",       d.sections},
+        {"lanes",          d.lanes},
+        {"lines",          d.lines},
+        {"stop_lines",     d.stop_lines},
+        {"junctions",      d.junctions},
+        {"traffic_lights", d.traffic_lights},
+        {"traffic_signs",  d.traffic_signs},
+        {"road_markers",   d.road_markers},
+        {"poles",          d.poles},
+        {"speed_bumps",    d.speed_bumps},
+        {"traffic_cones",  d.traffic_cones},
+        {"mpp_ids",        d.mpp_ids},
+        {"lane_line",      d.lane_line}
+    };
+}
+
+// ─────────────────────────────────────────────
+//  便捷工具函数
+// ─────────────────────────────────────────────
+
+/**
+ * @brief 将 LDData 序列化并写入 JSON 文件
+ * @param ld_data   待序列化数据
+ * @param file_path 输出文件路径（如 "/tmp/lddata.json"）
+ * @param indent    缩进空格数，-1 表示紧凑模式
+ * @return true  写入成功
+ * @return false 文件打开失败
+ */
+inline bool SaveLDDataToJson(const LDData &ld_data,
+                             const std::string &file_path,
+                             int indent = 2) {
+    std::ofstream ofs(file_path);
+    if (!ofs.is_open()) {
+        return false;
+    }
+    json j;
+    to_json(j, ld_data);
+    ofs << j.dump(indent);
+    return ofs.good();
+}
+
+}  // namespace vision
+}  // namespace vexus

--- a/include/lddata_transform.hpp
+++ b/include/lddata_transform.hpp
@@ -1,0 +1,153 @@
+#pragma once
+
+#include "vision_type/vision_type.hpp"
+
+namespace vexus {
+namespace vision {
+
+/**
+ * @brief 将 LDData 中所有 _lla 坐标字段转换为 ENU 坐标，
+ *        结果同时写入对应的 _ego 字段和 base 字段（center_points / boundary / points / centroid）。
+ *
+ * 调用前提：C++ 侧已通过 LLAConverter::Instance()->SetOrigin(...) 设置好 ENU 原点。
+ *
+ * 高度处理规则（与 TransformToENUCoordinateV2 保持一致）：
+ *   - 若 LLA 点的 z（高度）为 0，则用 actual_height 做投影，但 ENU z 置回 0；
+ *   - 否则直接用原始高度做投影。
+ *
+ * @param ld_data       待转换数据（in-place 修改）
+ * @param actual_height 高度为 0 时的替代值（单位：米），默认 16.0
+ * @return true  转换成功
+ * @return false ld_data 为空指针
+ */
+inline bool TransformLDDataToENU(LDData *ld_data, float actual_height = 16.0f) {
+    if (ld_data == nullptr) {
+        return false;
+    }
+
+    // ── 辅助：将单个 LLA Point3d 转为 ENU Point3d ──────────────────────────
+    // point3d.x = lon, point3d.y = lat, point3d.z = alt
+    auto lla_to_enu = [&](const Point3d &lla_pt) -> Point3d {
+        PointLLH point_llh(lla_pt.x, lla_pt.y, lla_pt.z);
+        Point3D  result;
+        if (point_llh.height == 0) {
+            LLAConverter::Instance()->LLA2XYZ(
+                PointLLH(lla_pt.x, lla_pt.y, static_cast<float64_t>(actual_height)),
+                &result);
+            result.z = lla_pt.z;  // 高度由 AssignHeight 统一赋值，此处 reset
+        } else {
+            LLAConverter::Instance()->LLA2XYZ(point_llh, &result);
+        }
+        return Point3d{static_cast<float>(result.x),
+                       static_cast<float>(result.y),
+                       static_cast<float>(result.z)};
+    };
+
+    // ── 辅助：批量转换点列表，同时写入 ego 容器和 base 容器 ────────────────
+    auto transform_points = [&](const std::vector<Point3d> &lla_pts,
+                                std::vector<Point3d>       &ego_pts,
+                                std::vector<Point3d>       &base_pts) {
+        ego_pts.resize(lla_pts.size());
+        base_pts.resize(lla_pts.size());
+        for (size_t i = 0; i < lla_pts.size(); ++i) {
+            ego_pts[i]  = lla_to_enu(lla_pts[i]);
+            base_pts[i] = ego_pts[i];
+        }
+    };
+
+    // ── 辅助：转换 ObjectData 的质心（centroid_lla → centroid_ego + centroid）
+    auto transform_centroid = [&](ObjectData &obj) {
+        Point3d enu         = lla_to_enu(obj.centroid_lla);
+        obj.centroid_ego    = enu;
+        obj.centroid        = enu;
+    };
+
+    // ── 1. 车道中心线 ──────────────────────────────────────────────────────
+    for (auto &lane : ld_data->lanes) {
+        transform_points(lane.center_points_lla,
+                         lane.center_points_ego,
+                         lane.center_points);
+    }
+
+    // ── 2. Section 中心线 ──────────────────────────────────────────────────
+    for (auto &section : ld_data->sections) {
+        transform_points(section.center_points_lla,
+                         section.center_points_ego,
+                         section.center_points);
+    }
+
+    // ── 3. Junction 边界 ───────────────────────────────────────────────────
+    for (auto &junction : ld_data->junctions) {
+        transform_points(junction.boundary_lla,
+                         junction.boundary_ego,
+                         junction.boundary);
+    }
+
+    // ── 4. LaneLink 参考点（无 _lla/_ego 字段，不做转换）─────────────────
+    // LaneLinkData::ref_points 没有对应的 _lla/_ego 变体，跳过。
+
+    // ── 5. 车道线（LineData -> LineSegmentData）────────────────────────────
+    for (auto &line : ld_data->lines) {
+        for (auto &seg : line.line_segments) {
+            transform_points(seg.points_lla,
+                             seg.points_ego,
+                             seg.points);
+        }
+    }
+
+    // ── 6. 停车线 ──────────────────────────────────────────────────────────
+    for (auto &stop_line : ld_data->stop_lines) {
+        transform_points(stop_line.points_lla,
+                         stop_line.points_ego,
+                         stop_line.points);
+    }
+
+    // ── 7. Area 边界 ───────────────────────────────────────────────────────
+    for (auto &area : ld_data->areas) {
+        transform_points(area.boundary_lla,
+                         area.boundary_ego,
+                         area.boundary);
+    }
+
+    // ── 8. 人行横道边界 ────────────────────────────────────────────────────
+    for (auto &cw : ld_data->cross_walks) {
+        transform_points(cw.boundary_lla,
+                         cw.boundary_ego,
+                         cw.boundary);
+    }
+
+    // ── 9. 减速带 ──────────────────────────────────────────────────────────
+    for (auto &bump : ld_data->speed_bumps) {
+        transform_points(bump.points_lla,
+                         bump.points_ego,
+                         bump.points);
+    }
+
+    // ── 10. 红绿灯 ─────────────────────────────────────────────────────────
+    for (auto &tl : ld_data->traffic_lights) {
+        transform_centroid(tl.object_data);
+    }
+
+    // ── 11. 交通标志 ───────────────────────────────────────────────────────
+    for (auto &ts : ld_data->traffic_signs) {
+        transform_centroid(ts.object_data);
+    }
+
+    // ── 12. 路面标记 ───────────────────────────────────────────────────────
+    for (auto &rm : ld_data->road_markers) {
+        transform_centroid(rm.object_data);
+    }
+
+    // ── 13. 交通锥 ─────────────────────────────────────────────────────────
+    for (auto &cone : ld_data->traffic_cones) {
+        transform_centroid(cone.object_data);
+    }
+
+    // ── 14. 杆（PoleData 无 _lla/_ego，不做转换）──────────────────────────
+    // PoleData::bottom_point / top_point 没有对应的 _lla/_ego 变体，跳过。
+
+    return true;
+}
+
+}  // namespace vision
+}  // namespace vexus

--- a/include/lddata_transform.hpp
+++ b/include/lddata_transform.hpp
@@ -9,41 +9,35 @@ namespace vision {
  * @brief 将 LDData 中所有 _lla 坐标字段转换为 ENU 坐标，
  *        结果同时写入对应的 _ego 字段和 base 字段（center_points / boundary / points / centroid）。
  *
- * 调用前提：C++ 侧已通过 LLAConverter::Instance()->SetOrigin(...) 设置好 ENU 原点。
+ * 逻辑对应 Python：
+ *   lla_converter = LLAConverter()
+ *   lla_converter.set_origin([lla_ref[0], lla_ref[1], lla_ref[2]])
+ *   enu_pt = lla_converter.lla2enu([lla[0], lla[1], lla[2]])
  *
- * 高度处理规则（与 TransformToENUCoordinateV2 保持一致）：
- *   - 若 LLA 点的 z（高度）为 0，则用 actual_height 做投影，但 ENU z 置回 0；
- *   - 否则直接用原始高度做投影。
- *
- * @param ld_data       待转换数据（in-place 修改）
- * @param actual_height 高度为 0 时的替代值（单位：米），默认 16.0
+ * @param ld_data   待转换数据（in-place 修改）
+ * @param lla_ref   ENU 原点，格式与 Point3d 一致（x=lon, y=lat, z=alt）
  * @return true  转换成功
  * @return false ld_data 为空指针
  */
-inline bool TransformLDDataToENU(LDData *ld_data, float actual_height = 16.0f) {
+inline bool TransformLDDataToENU(LDData *ld_data, const Point3d &lla_ref) {
     if (ld_data == nullptr) {
         return false;
     }
 
-    // ── 辅助：将单个 LLA Point3d 转为 ENU Point3d ──────────────────────────
-    // point3d.x = lon, point3d.y = lat, point3d.z = alt
+    // 对应 Python：lla_converter = LLAConverter(); lla_converter.set_origin(lla_ref)
+    LLAConverter lla_converter;
+    lla_converter.SetOrigin(PointLLH(lla_ref.x, lla_ref.y, lla_ref.z));
+
+    // 对应 Python：enu_pt = lla_converter.lla2enu([lla[0], lla[1], lla[2]])
     auto lla_to_enu = [&](const Point3d &lla_pt) -> Point3d {
-        PointLLH point_llh(lla_pt.x, lla_pt.y, lla_pt.z);
-        Point3D  result;
-        if (point_llh.height == 0) {
-            LLAConverter::Instance()->LLA2XYZ(
-                PointLLH(lla_pt.x, lla_pt.y, static_cast<float64_t>(actual_height)),
-                &result);
-            result.z = lla_pt.z;  // 高度由 AssignHeight 统一赋值，此处 reset
-        } else {
-            LLAConverter::Instance()->LLA2XYZ(point_llh, &result);
-        }
+        Point3D result;
+        lla_converter.LLA2XYZ(PointLLH(lla_pt.x, lla_pt.y, lla_pt.z), &result);
         return Point3d{static_cast<float>(result.x),
                        static_cast<float>(result.y),
                        static_cast<float>(result.z)};
     };
 
-    // ── 辅助：批量转换点列表，同时写入 ego 容器和 base 容器 ────────────────
+    // 批量转换点列表，同时写入 ego 容器和 base 容器
     auto transform_points = [&](const std::vector<Point3d> &lla_pts,
                                 std::vector<Point3d>       &ego_pts,
                                 std::vector<Point3d>       &base_pts) {
@@ -55,11 +49,11 @@ inline bool TransformLDDataToENU(LDData *ld_data, float actual_height = 16.0f) {
         }
     };
 
-    // ── 辅助：转换 ObjectData 的质心（centroid_lla → centroid_ego + centroid）
+    // 转换 ObjectData 的质心（centroid_lla → centroid_ego + centroid）
     auto transform_centroid = [&](ObjectData &obj) {
-        Point3d enu         = lla_to_enu(obj.centroid_lla);
-        obj.centroid_ego    = enu;
-        obj.centroid        = enu;
+        Point3d enu      = lla_to_enu(obj.centroid_lla);
+        obj.centroid_ego = enu;
+        obj.centroid     = enu;
     };
 
     // ── 1. 车道中心线 ──────────────────────────────────────────────────────
@@ -83,10 +77,7 @@ inline bool TransformLDDataToENU(LDData *ld_data, float actual_height = 16.0f) {
                          junction.boundary);
     }
 
-    // ── 4. LaneLink 参考点（无 _lla/_ego 字段，不做转换）─────────────────
-    // LaneLinkData::ref_points 没有对应的 _lla/_ego 变体，跳过。
-
-    // ── 5. 车道线（LineData -> LineSegmentData）────────────────────────────
+    // ── 4. 车道线（LineData -> LineSegmentData）────────────────────────────
     for (auto &line : ld_data->lines) {
         for (auto &seg : line.line_segments) {
             transform_points(seg.points_lla,
@@ -95,56 +86,53 @@ inline bool TransformLDDataToENU(LDData *ld_data, float actual_height = 16.0f) {
         }
     }
 
-    // ── 6. 停车线 ──────────────────────────────────────────────────────────
+    // ── 5. 停车线 ──────────────────────────────────────────────────────────
     for (auto &stop_line : ld_data->stop_lines) {
         transform_points(stop_line.points_lla,
                          stop_line.points_ego,
                          stop_line.points);
     }
 
-    // ── 7. Area 边界 ───────────────────────────────────────────────────────
+    // ── 6. Area 边界 ───────────────────────────────────────────────────────
     for (auto &area : ld_data->areas) {
         transform_points(area.boundary_lla,
                          area.boundary_ego,
                          area.boundary);
     }
 
-    // ── 8. 人行横道边界 ────────────────────────────────────────────────────
+    // ── 7. 人行横道边界 ────────────────────────────────────────────────────
     for (auto &cw : ld_data->cross_walks) {
         transform_points(cw.boundary_lla,
                          cw.boundary_ego,
                          cw.boundary);
     }
 
-    // ── 9. 减速带 ──────────────────────────────────────────────────────────
+    // ── 8. 减速带 ──────────────────────────────────────────────────────────
     for (auto &bump : ld_data->speed_bumps) {
         transform_points(bump.points_lla,
                          bump.points_ego,
                          bump.points);
     }
 
-    // ── 10. 红绿灯 ─────────────────────────────────────────────────────────
+    // ── 9. 红绿灯 ──────────────────────────────────────────────────────────
     for (auto &tl : ld_data->traffic_lights) {
         transform_centroid(tl.object_data);
     }
 
-    // ── 11. 交通标志 ───────────────────────────────────────────────────────
+    // ── 10. 交通标志 ───────────────────────────────────────────────────────
     for (auto &ts : ld_data->traffic_signs) {
         transform_centroid(ts.object_data);
     }
 
-    // ── 12. 路面标记 ───────────────────────────────────────────────────────
+    // ── 11. 路面标记 ───────────────────────────────────────────────────────
     for (auto &rm : ld_data->road_markers) {
         transform_centroid(rm.object_data);
     }
 
-    // ── 13. 交通锥 ─────────────────────────────────────────────────────────
+    // ── 12. 交通锥 ─────────────────────────────────────────────────────────
     for (auto &cone : ld_data->traffic_cones) {
         transform_centroid(cone.object_data);
     }
-
-    // ── 14. 杆（PoleData 无 _lla/_ego，不做转换）──────────────────────────
-    // PoleData::bottom_point / top_point 没有对应的 _lla/_ego 变体，跳过。
 
     return true;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

根据最新的结构体定义，更新序列化与坐标转换两个头文件。

---

## 文件 1：`include/lddata_json.hpp`

根据新结构体定义更新所有 `to_json` 序列化函数（详见首次提交）。

---

## 文件 2：`include/lddata_transform.hpp`

按 Python `lla2enu` 逻辑实现 `TransformLDDataToENU`。

### Python 参考逻辑
```python
def lla2enu(lla, lla_ref):
    lla_converter = LLAConverter()
    lla_converter.set_origin([lla_ref[0], lla_ref[1], lla_ref[2]])
    enu_pt = lla_converter.lla2enu([lla[0], lla[1], lla[2]])
    return enu_pt
```

### C++ 实现对应关系

| Python | C++ |
|--------|-----|
| `LLAConverter()` 局部实例 | 函数内 `LLAConverter lla_converter;` |
| `set_origin(lla_ref)` | `lla_converter.SetOrigin(PointLLH(lla_ref.x, lla_ref.y, lla_ref.z))` |
| `lla2enu(lla)` | `lla_converter.LLA2XYZ(PointLLH(...), &result)` |
| `lla_ref` 参数 | `const Point3d &lla_ref` 参数 |

### 与旧 `TransformToENUCoordinateV2` 的差异

| 旧 C++ | 新 C++ |
|--------|--------|
| 依赖全局单例 `LLAConverter::Instance()`，原点外部预设 | 局部实例，`lla_ref` 作为参数传入 |
| `actual_height` 高度替代逻辑 | 直接使用原始坐标，不做高度替换 |
| 函数签名 `(LDData*, float actual_height)` | 函数签名 `(LDData*, const Point3d& lla_ref)` |

### 覆盖范围

| 类型 | 转换字段 |
|------|---------|
| `LaneData` | `center_points_lla` → `center_points_ego` / `center_points` |
| `SectionData` | `center_points_lla` → `center_points_ego` / `center_points` |
| `JunctionData` | `boundary_lla` → `boundary_ego` / `boundary` |
| `LineSegmentData` | `points_lla` → `points_ego` / `points` |
| `StopLineData` | `points_lla` → `points_ego` / `points` |
| `AreaData` | `boundary_lla` → `boundary_ego` / `boundary` |
| `CrosswalkData` | `boundary_lla` → `boundary_ego` / `boundary` |
| `SpeedBumpData` | `points_lla` → `points_ego` / `points` |
| `TrafficLightData` | `object_data.centroid_lla` → `centroid_ego` / `centroid` |
| `TrafficSignData` | 同上 |
| `RoadMarkerData` | 同上 |
| `TrafficConeData` | 同上 |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b300073-0c4b-41ab-91e6-4789b23487ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b300073-0c4b-41ab-91e6-4789b23487ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

