### PR TITLE
Set up development environment with modern GCC and OpenCV 4 compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a C++ ORB-SLAM2 project enhanced with KLT optical flow tracking. It builds with CMake and has no package manager lockfiles.
+
+### Build toolchain
+
+- **Compiler**: Must use `g++-11` (GCC 11). The system default compiler (clang 18) lacks the C++ standard library headers needed. GCC 12+ triggers a `static_assert` in `std::map` due to an Eigen `aligned_allocator` type mismatch in `include/LoopClosing.h`.
+- **Eigen**: The project uses Eigen 3.3.7 installed at `/usr/local/include/eigen3`. The system Eigen 3.4.0 at `/usr/include/eigen3` is incompatible.
+- **Pangolin**: Built from source (v0.6) and installed at `/usr/local/lib/libpangolin.so`. Requires `CMAKE_CXX_FLAGS="-include cstdint"` when building with GCC 11+.
+- **OpenCV**: System OpenCV 4.6.0 is used. A compatibility header at `/usr/local/include/opencv/cv.h` bridges the deprecated `opencv/cv.h` include used by `include/ORBextractor.h`.
+
+### Build commands
+
+Full clean build from workspace root:
+
+```bash
+export CC=gcc-11 CXX=g++-11
+
+# 1. Extract vocabulary
+cd Vocabulary && tar zxvf ORBvoc.tar.gz && cd ..
+
+# 2. Build DBoW2
+cd Thirdparty/DBoW2 && mkdir -p build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_C_COMPILER=gcc-11 && make -j$(nproc) && cd ../../..
+
+# 3. Build g2o
+cd Thirdparty/g2o && mkdir -p build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_C_COMPILER=gcc-11 -DEIGEN3_INCLUDE_DIR=/usr/local/include/eigen3 && make -j$(nproc) && cd ../../..
+
+# 4. Build ORB_SLAM2
+mkdir -p build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_C_COMPILER=gcc-11 -DEIGEN3_INCLUDE_DIR=/usr/local/include/eigen3 && make -j$(nproc) && cd ..
+```
+
+### Running
+
+Executables are output to `build/`. They require `LD_LIBRARY_PATH` to include the library paths:
+
+```bash
+export LD_LIBRARY_PATH=/workspace/lib:/workspace/Thirdparty/DBoW2/lib:/workspace/Thirdparty/g2o/lib:/usr/local/lib:$LD_LIBRARY_PATH
+```
+
+Example (RGB-D with TUM dataset):
+```bash
+./build/rgbd_tum Vocabulary/ORBvoc.txt Examples/RGB-D/TUM1.yaml <path_to_dataset> <path_to_association_file>
+```
+
+### Key gotchas
+
+- The Pangolin viewer requires an X11 display (`DISPLAY=:1` is available in Cloud Agent VMs).
+- The `opencv/cv.h` compatibility shim at `/usr/local/include/opencv/` is essential; without it, `include/ORBextractor.h` won't compile against OpenCV 4.
+- `include/LoopClosing.h` has a fix: `const KeyFrame*` changed to `KeyFrame *const` in the `Eigen::aligned_allocator` template to match `std::map::value_type`.
+- `CMakeLists.txt` has an added line to force-include `opencv2/imgcodecs/legacy/constants_c.h` for `CV_LOAD_IMAGE_UNCHANGED`.
+- No automated test suite exists; validation is done by running example executables against camera datasets (TUM, KITTI, EuRoC).
+- No linter is configured for this C++ project.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ else( CMAKE_BUILD_TYPE MATCHES "Release" )
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}  -Wall -msse3 -std=c++11 -pthread -O3 -march=native -Wno-deprecated-declarations")
 endif( CMAKE_BUILD_TYPE MATCHES "Debug" )
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -include opencv2/imgcodecs/legacy/constants_c.h")
+
 LIST(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules)
 
 find_package(OpenCV  REQUIRED)

--- a/include/LoopClosing.h
+++ b/include/LoopClosing.h
@@ -47,7 +47,7 @@ public:
 
     typedef pair<set<KeyFrame*>,int> ConsistentGroup;    
     typedef map<KeyFrame*,g2o::Sim3,std::less<KeyFrame*>,
-        Eigen::aligned_allocator<std::pair<const KeyFrame*, g2o::Sim3> > > KeyFrameAndPose;
+        Eigen::aligned_allocator<std::pair<KeyFrame *const, g2o::Sim3> > > KeyFrameAndPose;
 
 public:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for ORB-SLAM2 with KLT optical flow, fixing build compatibility issues with modern compilers (GCC 11+) and OpenCV 4.

## Changes

### `include/LoopClosing.h`
- Fixed `Eigen::aligned_allocator` template argument: changed `const KeyFrame*` to `KeyFrame *const` in the `KeyFrameAndPose` typedef. This fixes a `static_assert` failure in `std::map` on GCC 9+ where the allocator's `value_type` must match `std::map::value_type`.

### `CMakeLists.txt`
- Added `-include opencv2/imgcodecs/legacy/constants_c.h` to `CMAKE_CXX_FLAGS` to provide `CV_LOAD_IMAGE_UNCHANGED` and other deprecated constants removed in OpenCV 4.

### `AGENTS.md` (new)
- Added Cloud Agent development instructions covering build toolchain requirements, build commands, runtime setup, and key compatibility gotchas.

## Testing

- Successfully built all targets: `libORB_SLAM2.so`, `rgbd_tum`, `mono_kitti`, `stereo_kitti`, `stereo_EuRoC`, `bin_vocabulary`
- Ran `rgbd_tum` with the TUM Freiburg1 XYZ RGB-D dataset (798 frames)
- Verified Pangolin 3D Map Viewer and LK OpticalFlow windows displayed correctly
- Camera trajectory and keyframe trajectory files saved successfully

[ORB-SLAM2 running with 3D map viewer and LK optical flow tracking](https://cursor.com/agents/bc-8d02d81b-88cc-4266-aa8e-98108b7e7c78/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Forbslam2_map_viewer_with_lk_optical_flow.webp)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d02d81b-88cc-4266-aa8e-98108b7e7c78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d02d81b-88cc-4266-aa8e-98108b7e7c78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

